### PR TITLE
generate typescript definitions so VSCode intellisense (mostly) works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ typings/
 build/
 
 lib/
+
+types/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-auto-edit",
-  "version": "2.2.1",
+  "version": "2.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10913,6 +10913,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "typescript-temporary-fork-for-jsdoc": {
+      "version": "3.6.0-insiders.20190802",
+      "resolved": "https://registry.npmjs.org/typescript-temporary-fork-for-jsdoc/-/typescript-temporary-fork-for-jsdoc-3.6.0-insiders.20190802.tgz",
+      "integrity": "sha512-j76opNh6ljAXDUDXr03+pOkITiATPbUlQlMp9pxD/SR3eNKAtIdHwOTf3dDspyGs8TGJQjQXMUiYqJr0gW+nCg==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "react-auto-edit",
-  "version": "2.2.3",
+  "version": "2.2.5",
   "description": "",
   "main": "lib/index.js",
+  "types": "types",
   "scripts": {
     "test": "jest",
-    "build": "babel src -d lib",
+    "build": "babel src -d lib && tsc",
     "watch": "nodemon --ignore lib --exec \"babel src -d lib\""
   },
   "author": "",
@@ -29,7 +30,8 @@
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
     "react-router-dom": "^4.3.1",
-    "react-test-renderer": "^16.10.1"
+    "react-test-renderer": "^16.10.1",
+    "typescript-temporary-fork-for-jsdoc": "^3.6.0-insiders.20190802"
   },
   "dependencies": {
     "base64-arraybuffer": "^0.2.0",

--- a/src/components/EditField.js
+++ b/src/components/EditField.js
@@ -7,6 +7,7 @@ import utils from '../utils';
  * @param {Object} props
  * @param {Controller} props.controller
  * @param {ItemContainer} props.container
+ * @param {string} props.fieldName
  */
 const EditField = ({
   fieldName, container, controller,

--- a/src/components/EditFieldArrayOfStrings.js
+++ b/src/components/EditFieldArrayOfStrings.js
@@ -5,6 +5,8 @@ import { observer } from 'mobx-react';
  * @typedef {import('../ItemContainer').default} ItemContainer
  * @param {Object} props
  * @param {ItemContainer} props.container
+ * @param {string} props.fieldName
+ * @param {boolean} props.readonly
  */
 const EditFieldArrayOfStrings = ({
   fieldName, container, readonly,

--- a/src/components/EditFieldBigString.js
+++ b/src/components/EditFieldBigString.js
@@ -5,6 +5,10 @@ import { observer } from 'mobx-react';
  * @typedef {import('../ItemContainer').default} ItemContainer
  * @param {Object} props
  * @param {ItemContainer} props.container
+ * @param {string} props.fieldName
+ * @param {number} props.maxLength
+ * @param {number} props.minLength
+ * @param {boolean} props.readonly
  */
 const EditFieldBigString = ({
   fieldName, container, maxLength, minLength, readonly,

--- a/src/components/EditFieldBoolean.js
+++ b/src/components/EditFieldBoolean.js
@@ -5,6 +5,8 @@ import { observer } from 'mobx-react';
  * @typedef {import('../ItemContainer').default} ItemContainer
  * @param {Object} props
  * @param {ItemContainer} props.container
+ * @param {string} props.fieldName
+ * @param {boolean} props.readonly
  */
 const EditFieldBoolean = ({
   fieldName, container, readonly,

--- a/src/components/EditFieldChildCollection.js
+++ b/src/components/EditFieldChildCollection.js
@@ -11,6 +11,7 @@ import utils from '../utils';
  * @param {Object} props
  * @param {ItemContainer} props.container
  * @param {Controller} props.controller
+ * @param {string} props.fieldName
  */
 const EditFieldChildCollection = ({
   fieldName, controller, container,

--- a/src/components/EditFieldDate.js
+++ b/src/components/EditFieldDate.js
@@ -9,6 +9,9 @@ dayjs.extend(utc);
  * @typedef {import('../ItemContainer').default} ItemContainer
  * @param {Object} props
  * @param {ItemContainer} props.container
+ * @param {string} props.fieldName
+ * @param {boolean} props.readonly
+ * @param {string} props.format
  */
 const EditFieldDate = ({
   fieldName, container, readonly, format,

--- a/src/components/EditFieldFk.js
+++ b/src/components/EditFieldFk.js
@@ -5,10 +5,15 @@ import Select from 'react-select';
 /**
  * @typedef {import('../Controller').default} Controller
  * @typedef {import('../ItemContainer').default} ItemContainer
+ */
+
+/**
  * @typedef {object} Props
  * @prop {Controller} controller
  * @prop {ItemContainer} container
- *
+ */
+
+/**
  * @extends {React.Component<Props>}
  */
 class EditFieldFk extends React.Component {

--- a/src/components/EditFieldGroup.js
+++ b/src/components/EditFieldGroup.js
@@ -10,6 +10,7 @@ import EditField from './EditField';
  * @param {Object} props
  * @param {ItemContainer} props.container
  * @param {Controller} props.controller
+ * @param {string} props.fieldName
  */
 const EditFieldGroup = ({
   fieldName, controller, container,

--- a/src/components/EditFieldGroupTabular.js
+++ b/src/components/EditFieldGroupTabular.js
@@ -10,6 +10,7 @@ import EditField from './EditField';
  * @param {Object} props
  * @param {ItemContainer} props.container
  * @param {Controller} props.controller
+ * @param {string} props.fieldName
  */
 const EditFieldGroupTabular = ({
   fieldName, container, controller,

--- a/src/components/EditFieldImage.js
+++ b/src/components/EditFieldImage.js
@@ -13,6 +13,8 @@ const readPromise = file => new Promise((resolve, reject) => {
  * @typedef {import('../ItemContainer').default} ItemContainer
  * @param {Object} props
  * @param {ItemContainer} props.container
+ * @param {string} props.fieldName
+ * @param {boolean} props.readonly
  */
 const EditFieldImage = ({
   fieldName, container, readonly,

--- a/src/components/EditFieldNumber.js
+++ b/src/components/EditFieldNumber.js
@@ -5,6 +5,10 @@ import { observer } from 'mobx-react';
  * @typedef {import('../ItemContainer').default} ItemContainer
  * @param {Object} props
  * @param {ItemContainer} props.container
+ * @param {string} props.fieldName
+ * @param {number} props.max
+ * @param {number} props.min
+ * @param {boolean} props.readonly
  */
 const EditFieldNumber = ({
   fieldName, container, max, min, readonly,

--- a/src/components/EditFieldRestrictedValues.js
+++ b/src/components/EditFieldRestrictedValues.js
@@ -6,6 +6,10 @@ import Select from 'react-select';
  * @typedef {import('../ItemContainer').default} ItemContainer
  * @param {Object} props
  * @param {ItemContainer} props.container
+ * @param {string} props.fieldName
+ * @param {boolean} props.isRequired
+ * @param {boolean} props.readonly
+ * @param {Array} props.suggestedValues
  */
 const EditFieldStringWithSuggestions = ({
   fieldName, container, readonly,

--- a/src/components/EditFieldString.js
+++ b/src/components/EditFieldString.js
@@ -5,6 +5,11 @@ import { observer } from 'mobx-react';
  * @typedef {import('../ItemContainer').default} ItemContainer
  * @param {Object} props
  * @param {ItemContainer} props.container
+ * @param {string} props.fieldName
+ * @param {number} props.maxLength
+ * @param {number} props.minLength
+ * @param {boolean} props.readonly
+ * @param {Array<string>} props.suggestedValues
  */
 const EditFieldString = ({
   fieldName, container, maxLength, minLength, readonly,

--- a/src/components/EditFieldUri.js
+++ b/src/components/EditFieldUri.js
@@ -5,6 +5,10 @@ import { observer } from 'mobx-react';
  * @typedef {import('../ItemContainer').default} ItemContainer
  * @param {Object} props
  * @param {ItemContainer} props.container
+ * @param {string} props.fieldName
+ * @param {number} props.maxLength
+ * @param {number} props.minLength
+ * @param {boolean} props.readonly
  */
 const EditFieldUri = ({
   fieldName, container, maxLength, minLength, readonly,

--- a/src/components/EditRoutes.js
+++ b/src/components/EditRoutes.js
@@ -68,6 +68,11 @@ const buildEditRoutes = (urlPath, controller, schemaPath = '', parentPks = []) =
   return result;
 };
 
+/**
+ * @typedef {import('../Controller').default} Controller
+ * @param {Object} props
+ * @param {Controller} props.controller
+ */
 const EditRoutes = ({ controller }) => {
   configure({
     ignoreTags: [],

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -14,6 +14,7 @@ import CancelButton from './CancelButton';
  * @param {Controller} props.controller
  * @param {string} title - title of menu, optional
  * @param {*} titleComponent - React component to use for the title element, optional
+ * @param {Location} location - the current window.location
  */
 const Menu = ({
   controller, title, titleComponent, location,

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import EditFieldGroupTabular from './components/EditFieldGroupTabular';
 import EditFieldNumber from './components/EditFieldNumber';
 import EditFieldString from './components/EditFieldString';
 import EditFieldUri from './components/EditFieldUri';
+import EditFieldRestrictedValues from './components/EditFieldRestrictedValues';
 import EditItem from './components/EditItem';
 import EditItemTabular from './components/EditItemTabular';
 import EditRoutes from './components/EditRoutes';
@@ -49,6 +50,7 @@ export {
   EditFieldNumber,
   EditFieldString,
   EditFieldUri,
+  EditFieldRestrictedValues,
   EditItem,
   EditItemTabular,
   EditRoutes,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "lib": ["es2017", "dom"],
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": false,
+    "strict": false,
+    "noImplicitThis": false,
+    "alwaysStrict": false,
+    "esModuleInterop": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "types",
+    "jsx": "react"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Typescript can compile plain JS files and include information from JSDoc comments to produce .d.ts type definitions that VSCode reads to produce intellisense.  This seems to work for everything but class based React components.  Function based React components are fine.

Uses a fork of the typescript compiler for now: https://dev.to/open-wc/generating-typescript-definition-files-from-javascript-5bp2

Fixes #1 