### PR TITLE
Support the case where collection searches return full entities, with…

### DIFF
--- a/__tests__/ApiProxy.test.js
+++ b/__tests__/ApiProxy.test.js
@@ -50,4 +50,14 @@ describe('ApiProxy', () => {
       expect(result).toBe('http://example.com/makes/m1/models/mod1/variants/v1');
     });
   });
+  describe('collectionSummaryIncludesFullEntities', () => {
+    it('returns the value of options.collectionSummariesIncludesFullEntities', () => {
+      let instance = new ApiProxy(schema, 'http://example.com',{
+        collectionSummariesIncludesFullEntities: true,
+      });
+      expect(instance.collectionSummaryIncludesFullEntities('makes')).toBe(true);
+      instance = new ApiProxy(schema, 'http://example.com');
+      expect(instance.collectionSummaryIncludesFullEntities('makes')).toBe(false);
+    });
+  });
 });

--- a/__tests__/Controller.test.js
+++ b/__tests__/Controller.test.js
@@ -264,6 +264,21 @@ describe('Controller', () => {
       await controller.loadDetail(container);
       expect(apiProxy.fetchJson).toHaveBeenCalledTimes(0);
     });
+    it('doesn\'t load the detail if summary method returns full entities', async () => {
+      const apiProxy = new ApiProxy(schema, 'http://localhost', {
+        collectionSummariesIncludesFullEntities: true,
+      });
+      apiProxy.fetchJson = jest.fn();
+      const controller = new Controller(schema, apiProxy);
+      controller.itemStore.load('makes', [], [{ makeId: 'ford' }],
+        ItemContainer.detailLevel.summary, ItemContainer.owner.summary);
+      const container = controller.itemStore.findContainer('makes', [],
+        { makeId: 'ford' }, ItemContainer.detailLevel.summary);
+      expect(container).toBeTruthy();
+      await controller.loadDetail(container);
+      expect(apiProxy.fetchJson).toHaveBeenCalledTimes(0);
+      expect(container.metadata.detailLevel).toEqual(ItemContainer.detailLevel.detail);
+    });
     it('loads foreign key lookup value', async () => {
       const fkSchema = Joi.object({
         parents: Joi.array().items({

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -6,7 +6,7 @@
     "joi": "^14.3.1",
     "joi-key-extensions": "^1.0.9",
     "react": "^16.9.0",
-    "react-auto-edit": "^2.2.3",
+    "react-auto-edit": "^2.2.6",
     "react-dom": "^16.9.0",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.1.1"

--- a/examples/basic/src/App.js
+++ b/examples/basic/src/App.js
@@ -41,6 +41,7 @@ const schema = Joi.object({
 const apiProxy = new ApiProxy(schema, 'https://jsonplaceholder.typicode.com', {
   pageSize: 10,
   concurrentFetchesLimit: 1,
+  collectionSummariesIncludesFullEntities: true,
 });
 const controller = new Controller(schema, apiProxy)
 

--- a/examples/customisation/package.json
+++ b/examples/customisation/package.json
@@ -8,7 +8,7 @@
     "mobx": "^5.13.0",
     "mobx-react": "^6.1.3",
     "react": "^16.9.0",
-    "react-auto-edit": "^2.2.3",
+    "react-auto-edit": "^2.2.6",
     "react-dom": "^16.9.0",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.1.1"

--- a/examples/customisation/src/App.js
+++ b/examples/customisation/src/App.js
@@ -38,6 +38,7 @@ class CustomApiProxy extends ApiProxy {
 const apiProxy = new CustomApiProxy(schema, 'https://jsonplaceholder.typicode.com', {
   pageSize: 10,
   concurrentFetchesLimit: 1,
+  collectionSummariesIncludesFullEntities: true,
 });
 
 let CustomEditBooleanField = ({ container, fieldName }) => <select

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-auto-edit",
-  "version": "2.2.3",
+  "version": "2.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-auto-edit",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "",
   "main": "lib/index.js",
   "types": "types",

--- a/readme.md
+++ b/readme.md
@@ -144,6 +144,7 @@ The ApiProxy class is in charge of mapping data requests to REST API calls
     * options.pagingMode - controls whether collection API calls should be paginated on the server side or client side. One of ApiProxy.pagingModes.clientSide and ApiProxy.pagingModes.serverSide.  Defaults to ApiProxy.pagingModes.clientSide (i.e. the target REST API is not pagination aware).
     * options.filterMode - controls whether filter/search of collections is handled server or client side.  One of ApiProxy.filterModes.clientSide and ApiProxy.filterModes.serverSide.  Defaults to ApiProxy.filterModes.clientSide (i.e. the target REST API does not know how to filter results).
     * options.pageSize - controls the size of search result pages.  Defaults to 10.
+    * options.collectionSummariesIncludesFullEntities - by default we assume REST API methods that return a collection of entities only include summary fields, and we need to call another API method to get a single entity to see all the fields.  If collectionSummariesIncludesFullEntities is true, then we accept the result of a collection API method as including the full entities, and don't make the extra calls.
 
 ## UIFactory
 The UIFactory class creates instances of the React UI components.  If you use the standard React UI components then you don't need to worry about this class.

--- a/src/ApiProxy.js
+++ b/src/ApiProxy.js
@@ -6,6 +6,7 @@ import utils from './utils';
  * @typedef {Object} Options
  * @property {number} concurrentFetchesLimit - Limits how many concurrent API calls can be made by the client
  * @property {number} pageSize - results page size (where this is under client's control)
+ * @property {boolean} collectionSummariesIncludesFullEntities - indicates that the API methods to get collection search results include all the entity fields and we don't need to seperately load detail
  * @property {ApiProxy.pagingModes} pagingMode
  * @property {ApiProxy.filterModes} filterMode
  */
@@ -21,6 +22,7 @@ class ApiProxy {
       concurrentFetchesLimit: 100,
       pagingMode: ApiProxy.pagingModes.clientSide,
       filterMode: ApiProxy.filterModes.clientSide,
+      collectionSummariesIncludesFullEntities: false,
       pageSize: 10,
     };
     const fullOptions = Object.assign(defaults, options || {});
@@ -28,6 +30,8 @@ class ApiProxy {
     this.baseApiPath = baseApiPath;
     this.pagingMode = fullOptions.pagingMode;
     this.pageSize = fullOptions.pageSize;
+    this.collectionSummariesIncludesFullEntities = fullOptions
+      .collectionSummariesIncludesFullEntities;
     this.filterMode = fullOptions.filterMode;
     this.inFlightItems = observable([]);
     this.limit = pLimit(fullOptions.concurrentFetchesLimit);
@@ -162,6 +166,11 @@ class ApiProxy {
     url = `${url}?${this.getPageAndFilterParams(page, filter).join('&')}`;
     const rawResult = await this.fetchJson(url);
     return this.paginateAndFilterResults(rawResult, collectionSchemaPath, page, filter);
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  collectionSummaryIncludesFullEntities(collectionSchemaPath) {
+    return !!this.collectionSummariesIncludesFullEntities;
   }
 
   filterResults(itemSchemaDesc, items, filter) {

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -235,6 +235,13 @@ class Controller {
    */
   async loadDetail(container) {
     if (container.metadata.detailLevel !== ItemContainer.detailLevel.detail) {
+      if (this.apiProxy
+        .collectionSummaryIncludesFullEntities(container.metadata.collectionSchemaPath)) {
+        // the API method to get collection summary returns full details so we don't need
+        // to call a REST API, just flag the existing container
+        container.upgradeSummaryToDetail(container.item);
+        return;
+      }
       const data = await this.apiProxy.fetchItemDetail(
         `${container.metadata.collectionSchemaPath}.[]`,
         container.metadata.parentIds, container.item,


### PR DESCRIPTION
… all fields present, not just summary fields  (fixes #25)