### PR TITLE
fix minor css issues for tabular and child tabular collections

### DIFF
--- a/examples/basic/package-lock.json
+++ b/examples/basic/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "basic-example",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,12 +1,12 @@
 {
   "name": "basic-example",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "private": true,
   "dependencies": {
     "joi": "^14.3.1",
     "joi-key-extensions": "^1.0.9",
     "react": "^16.9.0",
-    "react-auto-edit": "^2.3.3",
+    "react-auto-edit": "^2.3.4",
     "react-dom": "^16.9.0",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.1.1"

--- a/examples/customisation/package-lock.json
+++ b/examples/customisation/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "customisation-example",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/examples/customisation/package.json
+++ b/examples/customisation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "customisation-example",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "private": true,
   "dependencies": {
     "joi": "^14.3.1",
@@ -8,7 +8,7 @@
     "mobx": "^5.13.0",
     "mobx-react": "^6.1.3",
     "react": "^16.9.0",
-    "react-auto-edit": "^2.3.3",
+    "react-auto-edit": "^2.3.4",
     "react-dom": "^16.9.0",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-auto-edit",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-auto-edit",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "",
   "main": "lib/index.js",
   "types": "types",

--- a/static/Edit.css
+++ b/static/Edit.css
@@ -29,7 +29,7 @@
 .Ed-child-collection-container {
   display: inline-block;
   margin: -4px;
-  max-width: 100%;
+  max-width: 96vw;
 }
 
 .Ed-tabular-collection {
@@ -38,6 +38,7 @@
   table-layout: fixed;
   width: 100%;
   display: block;
+  padding-bottom: 15px;
 }
 
 .Ed-tabular-collection td {


### PR DESCRIPTION
the child collection container always displayed a horizontal scroll bar, 
the tabular collection horiz scroll bar was too close to the last record so was hard to use